### PR TITLE
Refactor proof configuration handling in LeanClient and AsyncLeanClient

### DIFF
--- a/packages/client/lean_runner/client/aio/client.py
+++ b/packages/client/lean_runner/client/aio/client.py
@@ -1,5 +1,4 @@
 import asyncio
-import json
 import logging
 import os
 from collections.abc import AsyncIterable, Iterable
@@ -61,10 +60,11 @@ class AsyncLeanClient:
         session = await self._get_session()
 
         proof_content = await self._get_proof_content(proof)
+        config = config or ProofConfig()
 
         data = {
             "proof": proof_content,
-            "config": json.dumps(config) if config else "{}",
+            "config": config.model_dump_json(),
         }
 
         response = await session.post("/prove/submit", data=data)
@@ -80,10 +80,11 @@ class AsyncLeanClient:
         session = await self._get_session()
 
         proof_content = await self._get_proof_content(proof)
+        config = config or ProofConfig()
 
         data = {
             "proof": proof_content,
-            "config": json.dumps(config) if config else "{}",
+            "config": config.model_dump_json(),
         }
 
         response = await session.post("/prove/check", data=data, timeout=config.timeout)

--- a/packages/client/lean_runner/client/client.py
+++ b/packages/client/lean_runner/client/client.py
@@ -73,12 +73,11 @@ class LeanClient:
         session = self._get_session()
 
         proof_content = self._get_proof_content(proof)
+        config = config or ProofConfig()
 
         data = {
             "proof": proof_content,
-            "config": config.model_dump_json()
-            if config
-            else ProofConfig().model_dump_json(),
+            "config": config.model_dump_json(),
         }
 
         response = session.post("/prove/submit", data=data)

--- a/packages/server/lean_server/app/serve.py
+++ b/packages/server/lean_server/app/serve.py
@@ -18,7 +18,6 @@ def launch(*, config: Config) -> FastAPI:
 def main():
     args = parse_args()
     config = get_config(args)
-    print(config)
     app = launch(config=config)
     uvicorn.run(
         app,


### PR DESCRIPTION
- Simplified the configuration assignment by directly using `config.model_dump_json()` instead of conditional checks.
- Removed unnecessary JSON serialization in the server-side proof submission and check endpoints.
- Cleaned up imports and removed unused logging in the server's `prove.py` and `serve.py` files for better code clarity.